### PR TITLE
docs: reorganize readmes for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,26 @@
 # HeliosBillyBass
 
-Consolidated Arduino animatronics workspace with full history preserved (via git subtree).
+Consolidated Arduino animatronics workspace with full history preserved via git subtree.
 
-## Structure
-- firmware/projects/billybass_v2: fresh attempt at fish control
-- firmware/projects/archive/btbillybass: archived working prototype
-- firmware/projects/helios: Helios docs, mkdocs site, and examples
+## Overview
 
-Each subproject keeps its own docs and assets within its folder.
+This repository groups multiple firmware efforts for the singing fish and supporting Helios documentation.
 
-## Development
-- Work inside the subfolders under `firmware/`
-- Open the `.ino` projects in Arduino IDE or your preferred environment
+## Repository layout
 
-## Origin
-This monorepo consolidates the previous repositories after history-preserving merge.
+- `firmware/` – microcontroller workspace
+  - `projects/billybass_v2/` – fresh attempt at controlling the fish
+  - `projects/archive/btbillybass/` – archived Bluetooth Billy Bass prototype (read-only)
+  - `projects/helios/` – documentation site, examples, and supporting materials
+
+Each project keeps its own source, docs, and libraries within its folder.
+
+## Getting started
+
+1. Navigate to a project under `firmware/projects/`.
+2. Open the respective `.ino` file in the Arduino IDE or your preferred environment.
+3. See `firmware/README.md` for more details.
+
+## History
+
+This monorepo consolidates previous repositories while preserving their history.

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -1,26 +1,27 @@
 # Firmware Workspace
 
-This workspace hosts multiple firmware-related projects under a unified structure.
+This workspace hosts multiple firmware projects under a unified structure.
 
-## Layout
+## Directory layout
 
-- `projects/`
-  - `billybass_v2/` – fresh attempt at controlling the fish
-  - `archive/btbillybass/` – original Bluetooth Billy Bass firmware (read-only)
-  - `helios/` – documentation site, examples, and supporting materials
+| Path | Description | Entry point |
+| ---- | ----------- | ----------- |
+| `projects/billybass_v2/` | fresh attempt at controlling the fish | `billybass_v2.ino` |
+| `projects/archive/btbillybass/` | original Bluetooth Billy Bass firmware (read-only) | `BTBillyBass.ino` |
+| `projects/helios/` | documentation site, examples, and supporting materials | n/a |
 
 ## Quick start
 
-- New attempt: open `projects/billybass_v2/billybass_v2.ino` in the Arduino IDE and begin implementing.
-- Archived firmware: open `projects/archive/btbillybass/BTBillyBass/BTBillyBass.ino` for reference.
-- Docs and examples: see `projects/helios/README.md` and `projects/helios/docs/`.
+1. For the new fish controller, open `projects/billybass_v2/billybass_v2.ino` in the Arduino IDE.
+2. For the archived prototype, open `projects/archive/btbillybass/BTBillyBass/BTBillyBass.ino` for reference.
+3. For docs and examples, see `projects/helios/README.md` and `projects/helios/docs/`.
 
 ## Conventions
 
 - Add new firmware projects under `projects/<project-name>/`.
-- Keep each project self-contained: source, docs, examples, and libraries stay within the project folder.
-- Cross-project utilities can later live under top-level `tools/` or `shared/` if needed.
+- Keep each project self-contained with its own source, docs, examples, and libraries.
+- Shared utilities may later live under top-level `tools/` or `shared/`.
 
 ## Notes
 
-This consolidates legacy `btb/` and `helios/` content into `projects/` for a cleaner monorepo layout.
+This consolidation replaces legacy `btb/` and `helios/` content with a clearer `projects/` layout.

--- a/firmware/projects/README.md
+++ b/firmware/projects/README.md
@@ -1,14 +1,11 @@
 # Projects
 
-- `billybass_v2/`
-  - Path: `projects/billybass_v2`
-  - Entry point: `billybass_v2.ino`
-- `archive/btbillybass/`
-  - Path: `projects/archive/btbillybass/BTBillyBass`
-  - Entry point: `BTBillyBass.ino`
-  - Docs: `projects/archive/btbillybass/BTBillyBass/docs/`
-- `helios/`
-  - Path: `projects/helios`
-  - Docs site and examples supporting the BTBillyBass project
+Quick reference for available firmware efforts.
+
+| Project | Path | Entry point | Notes |
+| ------- | ---- | ----------- | ----- |
+| `billybass_v2` | `projects/billybass_v2` | `billybass_v2.ino` | fresh attempt at fish control |
+| `archive/btbillybass` | `projects/archive/btbillybass/BTBillyBass` | `BTBillyBass.ino` | docs in `projects/archive/btbillybass/BTBillyBass/docs/` |
+| `helios` | `projects/helios` | n/a | docs site and examples supporting the BTBillyBass project |
 
 Add new projects under `projects/<project-name>/` and keep them self-contained.


### PR DESCRIPTION
## Summary
- clarify project layout and usage in root README
- reorganize firmware README with project table and step-by-step guidance
- streamline per-project reference README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1024bc5ec8327989d039d85c946ec